### PR TITLE
Fix compiler warnings.

### DIFF
--- a/spir_name_mangler/ParameterType.cpp
+++ b/spir_name_mangler/ParameterType.cpp
@@ -61,7 +61,7 @@ namespace SPIR {
     m_address_space = attr;
   }
 
-  const TypeAttributeEnum PointerType::getAddressSpace() const {
+  TypeAttributeEnum PointerType::getAddressSpace() const {
     return m_address_space;
   }
 

--- a/spir_name_mangler/ParameterType.h
+++ b/spir_name_mangler/ParameterType.h
@@ -199,13 +199,13 @@ namespace SPIR {
 
     /// @brief Returns the pointer's address space.
     /// @return pointer's address space.
-    const TypeAttributeEnum getAddressSpace() const;
+    TypeAttributeEnum getAddressSpace() const;
 
     /// @brief Adds or removes a pointer's qualifier.
     /// @param TypeAttributeEnum qual - qualifier to add/remove.
     /// @param bool enabled - true if qualifier should exist false otherwise.
     ///        default is set to false.
-    void PointerType::setQualifier(TypeAttributeEnum qual, bool enabled);
+    void setQualifier(TypeAttributeEnum qual, bool enabled);
 
     /// @brief Checks if the pointer has a certain qualifier.
     /// @param TypeAttributeEnum qual - qualifier to check.


### PR DESCRIPTION
Building spir-tools failed on Debian wheezy with: 

```
 [ 90%] Building CXX object tools/spir-tools/spir_name_mangler/CMakeFiles/SpirNameMangler.dir/FunctionDescriptor.cpp.o
In file included from /home/kraiskil/llvm/spir/llvm-3.2.src/tools/spir-tools/spir_name_mangler/FunctionDescriptor.h:11:0,
                 from /home/kraiskil/llvm/spir/llvm-3.2.src/tools/spir-tools/spir_name_mangler/FunctionDescriptor.cpp:8:
/home/kraiskil/llvm/spir/llvm-3.2.src/tools/spir-tools/spir_name_mangler/ParameterType.h:202:47: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
/home/kraiskil/llvm/spir/llvm-3.2.src/tools/spir-tools/spir_name_mangler/ParameterType.h:208:10: error: extra qualification ‘SPIR::PointerType::’ on member ‘setQualifier’ [-fpermissive]
make[2]: *** [tools/spir-tools/spir_name_mangler/CMakeFiles/SpirNameMangler.dir/FunctionDescriptor.cpp.o] Fel 1
make[1]: *** [tools/spir-tools/spir_name_mangler/CMakeFiles/SpirNameMangler.dir/all] Fel 2
make: *** [all] Fel 2
```

After the attached patches, it compiles fine.
